### PR TITLE
fix configuration. ScalarNode name must not contain .

### DIFF
--- a/DataCollector/XhprofCollector.php
+++ b/DataCollector/XhprofCollector.php
@@ -34,8 +34,8 @@ class XhprofCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
 
-        require_once $this->container->getParameter('jns_xhprof.location.lib');
-        require_once $this->container->getParameter('jns_xhprof.location.runs');
+        require_once $this->container->getParameter('jns_xhprof.location_lib');
+        require_once $this->container->getParameter('jns_xhprof.location_runs');
 
         $xhprof_data = xhprof_disable();
 
@@ -49,7 +49,7 @@ class XhprofCollector extends DataCollector
         
         $this->data = array(
             'xhprof' => $run_id,
-            'xhprof_url' => $this->container->getParameter('jns_xhprof.location.web'),
+            'xhprof_url' => $this->container->getParameter('jns_xhprof.location_web'),
         );
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration
 
         $rootNode
             ->children()
-                ->scalarNode('location.lib')->defaultValue('/opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_lib.php')->end()
-                ->scalarNode('location.runs')->defaultValue('/opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_runs.php')->end()
-                ->scalarNode('location.web')->defaultValue('http://xhprof')->end()
+                ->scalarNode('location_lib')->defaultValue('/opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_lib.php')->end()
+                ->scalarNode('location_runs')->defaultValue('/opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_runs.php')->end()
+                ->scalarNode('location_web')->defaultValue('http://xhprof')->end()
                 ->scalarNode('enabled')->defaultFalse()->end()
             ->end();
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ To change these settings for your environment you can override the defaults by
 defining the following settings in your config. The config is usually located at `app/config/config.yml`.
 
     jns_xhprof:
-        location.lib: /opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_lib.php
-        location.runs: /opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_runs.php
-        location.web: http://xhprof.localhost
+        location_lib:   /opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_lib.php
+        location_runs:  /opt/local/www/php5-xhprof/xhprof_lib/utils/xhprof_runs.php
+        location_web:   http://xhprof.localhost
+        enabled:        true
 
 [1]: http://mirror.facebook.net/facebook/xhprof/doc.html
 [2]: http://www.macports.org/


### PR DESCRIPTION
Dear Jonas,

Installing your XhprofBundle with the README indications, I systematically got the following error on my project :

``` php
Fatal error: Uncaught exception 'InvalidArgumentException' with message 'The name must not contain ".".' in ../src/Symfony/Component/Config/Definition/BaseNode.php:44
```

It seems that a scalar name can't contain a dot character. This pull request fix the issue.
