### PR TITLE
The xhprof url is now in the response headers

### DIFF
--- a/DataCollector/XhprofCollector.php
+++ b/DataCollector/XhprofCollector.php
@@ -44,6 +44,8 @@ class XhprofCollector extends DataCollector
             'xhprof' => $this->runId,
             'xhprof_url' => $this->container->getParameter('jns_xhprof.location_web'),
         );
+        
+        $response->headers->set('X-Xhprof-Url', $this->getXhprofUrl());
     }
 
     public function startProfiling()


### PR DESCRIPTION
Hey!

That's way easier to use when developing HTTP Apis :)
