### PR TITLE
Do not enable profiler if xhprof is not installed on server + add extension required on composer

### DIFF
--- a/DependencyInjection/JnsXhprofExtension.php
+++ b/DependencyInjection/JnsXhprofExtension.php
@@ -17,7 +17,7 @@ class JnsXhprofExtension extends Extension
     protected $resources = array(
         'services' => 'services.xml',
     );
-    
+
     /**
      * Loads the services based on your application configuration.
      *
@@ -30,9 +30,9 @@ class JnsXhprofExtension extends Extension
         $configuration = new Configuration();
         $config = $processor->process($configuration->getConfigTree(), $configs);
 
-        if ($config['enabled']) {
+        if ($config['enabled'] && function_exists('xhprof_enable')) {
             $this->loadDefaults($container);
-            
+
             foreach ($config as $key => $value) {
                 $container->setParameter($this->getAlias().'.'.$key, $value);
             }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "ext-xhprof": "*"
     },
     "autoload": {
         "psr-0": { "Jns\\Bundle\\XhprofBundle": "" }


### PR DESCRIPTION
Hi,

I added `ext-xhprof` on composer.json.

And i added a verification of php xhprof extension on DependencyInjection/Extension. Because we could have installed this bundle in an environment which has xhprof extension and then deploy it on an other environment.
Calling composer install will be OK (coz .lock exists) and we'll have xhprof bundle. But if we dont' have xhprof extension, we'll have error due to call of xhprof functions.
