### PR TITLE
Supports of 2.* instead of >=2.2, doctrine has to be suggested, ext-xhpr...

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are on a mac you can easily install it via [Macports][2]
 1. ### Composer
 
   Add the following dependencies to your projects composer.json file:
-    
+
     ```json
     "require": {
         # ..
@@ -34,6 +34,9 @@ If you are on a mac you can easily install it via [Macports][2]
         # ..
     }
     ```
+
+  Of course, you have to install ![xhprof library](http://php.net/manual/fr/book.xhprof.php) in your server.
+  At this moment, `ext-xhprof` is not required because your application could be deployed to a server without xhprof.
 
 2. ### Old way by adding to your vendor/bundles/ dir
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "ext-xhprof": "*",
-        "symfony/http-kernel": ">=2.1,<3.0",
-        "symfony/dependency-injection": ">=2.1,<3.0",
-        "doctrine/orm": "~2.2,>=2.2.3",
-        "doctrine/doctrine-bundle": "1.2.*"
+        "symfony/http-kernel": "2.*",
+        "symfony/dependency-injection": "2.*"
+    },
+    "suggest": {
+        "ext-xhprof": "Hierarchical Profiler for PHP",
+        "doctrine/orm": "Persist details in a storage via doctrine"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Supports logging system (2.*)
Xhprof extension has to be suggested because we could deploy application in a server without extension.
Doctrine has to be suggested too, this bundle could work without, there is no conflict at this moment with any version of doctrine.
