### PR TITLE
RequestListener return header with xhprof URL instead of id.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ class Configuration
                 ->scalarNode('sample_size')->defaultValue(1)->end()
                 ->scalarNode('enabled')->defaultFalse()->end()
                 ->scalarNode('request_query_argument')->defaultFalse()->end()
-                ->scalarNode('response_header')->defaultValue('X-Xhprof-Run-Id')->end()
+                ->scalarNode('response_header')->defaultValue('X-Xhprof-Url')->end()
                 ->enumNode('command')
                     ->values(array('on', 'option', 'off'))
                     ->defaultValue('option')

--- a/RequestListener.php
+++ b/RequestListener.php
@@ -89,7 +89,7 @@ class RequestListener
 
         $headerName = $this->container->getParameter('jns_xhprof.response_header');
         if ($headerName) {
-            $event->getResponse()->headers->set($headerName, $link);
+            $event->getResponse()->headers->set($headerName, $this->collector->getXhprofUrl());
         }
     }
 }


### PR DESCRIPTION
Replace `X-Xhprof-Run-Id` by  `X-Xhprof-Url` and return an **url** instead of an **id**.
