### PR TITLE
tweaks to the command line profiling

### DIFF
--- a/CommandListener.php
+++ b/CommandListener.php
@@ -108,7 +108,19 @@ class CommandListener
     public function onCommand(ConsoleCommandEvent $event)
     {
         $command = $event->getCommand()->getName();
-        if ('list' == $command || 'help' == $command) {
+        $system = array(
+            'list',
+            'help',
+            'assetic:dump',
+            'assets:install',
+            'config:dump-reference',
+            'container:debug',
+            'router:debug',
+            'cache:clear',
+            'cache:warmup',
+            'cache:create-cache-class',
+        );
+        if (in_array($command, $system)) {
             return;
         }
         if ('off' == $this->mode ||
@@ -122,7 +134,10 @@ class CommandListener
             }
         }
 
-        $this->collector->startProfiling();
+
+        if ($this->collector->startProfiling()) {
+            $event->getOutput()->writeln("XHProf starting run\n---");
+        }
     }
 
     /**
@@ -141,7 +156,7 @@ class CommandListener
 
 
         $event->getOutput()->writeln(sprintf(
-            "\n\n---\nXHProf run link <info>%s</info>",
+            "\n---\nXHProf run link <info>%s</info>",
             $this->collector->getXhprofUrl()
         ));
     }

--- a/DataCollector/XhprofCollector.php
+++ b/DataCollector/XhprofCollector.php
@@ -51,11 +51,13 @@ class XhprofCollector extends DataCollector
 
     /**
      * Start profiling with probability according to sample size.
+     *
+     * @return boolean whether profiling was started or not.
      */
     public function startProfiling()
     {
         if (mt_rand(1, $this->container->getParameter('jns_xhprof.sample_size')) != 1) {
-            return;
+            return false;
         }
 
         $this->collecting = true;
@@ -64,6 +66,8 @@ class XhprofCollector extends DataCollector
         if ($this->logger) {
             $this->logger->debug('Enabled XHProf');
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
better feedback and do not profile core symfony system commands.

i did not add doctrine to this pattern - that would be a case for command_exclude_patterns imho.
