### PR TITLE
[Feature] Remove request query argument from query bag once used

### DIFF
--- a/RequestListener.php
+++ b/RequestListener.php
@@ -46,6 +46,8 @@ class RequestListener
         $requestQueryArgument = $this->container->getParameter('jns_xhprof.request_query_argument');
         if ($requestQueryArgument && is_null($request->query->get($requestQueryArgument))) {
             return;
+        } else {
+            $request->query->remove($requestQueryArgument);
         }
 
         $uri = $request->getRequestUri();


### PR DESCRIPTION
When using request_query_argument parameter it stay in query parameter bag.
In our app we control parameters sent, so having an additional unknown parameter throw an exception.
So I juste remove it from query parameter bag once he's not usefull anymore
