### PR TITLE
Prevent "Undefined index: xhprof" in Symfony 2.6

### DIFF
--- a/DataCollector/XhprofCollector.php
+++ b/DataCollector/XhprofCollector.php
@@ -35,6 +35,8 @@ class XhprofCollector extends DataCollector
         $this->logger    = $logger;
         $this->doctrine  = $doctrine;
         $this->data['xhprof'] = null;
+        $this->data['source'] = null;
+        $this->data['xhprof_url'] = null;
     }
 
     /**


### PR DESCRIPTION
When using request_query_argument but not setting the get parameter in the URL there was a "Undefined index: xhprof" error
