### PR TITLE
Fix missing profiling header on ajax requests

### DIFF
--- a/DataCollector/XhprofCollector.php
+++ b/DataCollector/XhprofCollector.php
@@ -98,7 +98,7 @@ class XhprofCollector extends DataCollector
     public function stopProfiling($serverName, $uri)
     {
         if (!$this->collecting) {
-            return false;
+            return $this->data['xhprof'] ? $this->data['xhprof'] : false;
         }
 
         $this->collecting = false;


### PR DESCRIPTION
On ajax requests, the xhprof profiler stops in a previous listener (not in Response listener).
Because of that, the `$this->collector->stopProfiling` call returned wrong run id (link) in the `onCoreResponse` event.