### PR TITLE
Revert "Throw error if bundle is enabled but xhprof library is not"

### DIFF
--- a/DependencyInjection/JnsXhprofExtension.php
+++ b/DependencyInjection/JnsXhprofExtension.php
@@ -2,7 +2,6 @@
 
 namespace Jns\Bundle\XhprofBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -31,15 +30,11 @@ class JnsXhprofExtension extends Extension
         $configuration = new Configuration();
         $config = $processor->process($configuration->getConfigTree(), $configs);
 
-        if ($config['enabled']) {
-            if (function_exists('xhprof_enable')) {
-                $this->loadDefaults($container);
+        if ($config['enabled'] && function_exists('xhprof_enable')) {
+            $this->loadDefaults($container);
 
-                foreach ($config as $key => $value) {
-                    $container->setParameter($this->getAlias().'.'.$key, $value);
-                }
-            } else {
-                throw new InvalidConfigurationException("Xhprof Bundle is enabled but the xhprof extension is not enabled.");
+            foreach ($config as $key => $value) {
+                $container->setParameter($this->getAlias().'.'.$key, $value);
             }
         }
     }


### PR DESCRIPTION
Perhaps it is better to revert these changes... 