### PR TITLE
replace abandoned facebook/xhprof dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "symfony/http-kernel": "2.*",
         "symfony/dependency-injection": "2.*",
-        "facebook/xhprof": "dev-master@dev"
+        "lox/xhprof": "dev-master@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1.3",


### PR DESCRIPTION
see https://packagist.org/packages/facebook/xhprof

> This package is abandoned and no longer maintained. The author suggests using the lox/xhprof package instead.