### PR TITLE
Require renamed xhprof package and use PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.2",
         "symfony/http-kernel": "2.*",
         "symfony/dependency-injection": "2.*",
-        "facebook/xhprof": "dev-master@dev"
+        "lox/xhprof": "dev-master@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1.3",
@@ -26,11 +26,10 @@
         "doctrine/orm": "Persist details in a storage via doctrine"
     },
     "autoload": {
-        "psr-0": {
-            "Jns\\Bundle\\XhprofBundle": ""
+        "psr-4": {
+            "Jns\\Bundle\\XhprofBundle\\": ""
         }
     },
-    "target-dir": "Jns/Bundle/XhprofBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"


### PR DESCRIPTION
- `target-dir` is deprecated
- facebook/xhprof was renamed, see https://github.com/lox/xhprof/commit/0ca0360f67dbfc961376c6e486f3da9fae3f6888 and https://github.com/lox/xhprof/commit/c64571f892bda1298bad9c5e94ede0bc3f0e4627