### PR TITLE
Symfony3 compatibility

### DIFF
--- a/EventListener/CommandListener.php
+++ b/EventListener/CommandListener.php
@@ -4,7 +4,6 @@ namespace Jns\Bundle\XhprofBundle\EventListener;
 
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Jns\Bundle\XhprofBundle\DataCollector\XhprofCollector;
@@ -78,19 +77,14 @@ class CommandListener
      */
     private function isProfileOption(ConsoleCommandEvent $event)
     {
-        $inputDefinition = $event->getCommand()->getApplication()->getDefinition();
+        $definition = $event->getCommand()->getDefinition();
 
-        $inputDefinition->addOption(
+        $definition->addOption(
             new InputOption($this->optionName, null, InputOption::VALUE_NONE, '<info>JnsXhprofBundle</info>: Whether to profile this command with xhprof', null)
         );
 
-        // merge the application's input definition
-        $event->getCommand()->mergeApplicationDefinition();
-
-        $input = new ArgvInput();
-
-        // we use the input definition of the command
-        $input->bind($event->getCommand()->getDefinition());
+        $input = $event->getInput();
+        $input->bind($definition);
 
         return $input->getOption($this->optionName);
     }

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "symfony/http-kernel": "2.*",
-        "symfony/dependency-injection": "2.*",
-        "lox/xhprof": "dev-master@dev"
+        "php": "^5.3.2|^7.0",
+        "symfony/http-kernel": "^2.3|^3.0",
+        "symfony/dependency-injection": "^2.3|^3.0",
+        "pbweb/xhprof": "^1.0"
     },
     "require-dev": {
         "doctrine/common": "^2.5",
-        "phpspec/prophecy": "~1.1.2",
-        "phpunit/phpunit": "~4.1.3"
+        "symfony/console":"^2.8|^3.0",
+        "phpspec/prophecy": "^1.1.2",
+        "phpunit/phpunit": "^4.1.3"
     },
     "suggest": {
         "ext-xhprof": "Hierarchical Profiler for PHP",
@@ -34,10 +35,10 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         }
-     },
-     "config": {
+    },
+    "config": {
         "bin-dir": "bin/"
-     }
+    }
 }


### PR DESCRIPTION
- Symfony3 compatibility

- Fix global `--xhprof` command option, broken since symfony/console 2.8 (see #82)

Note that this breaks compatibility with symfony/console <2.8

- Use a stable version of xhprof in composer

Users of this bundle are no longer required to include xhprof with an unbound version constaint (see: https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md)